### PR TITLE
Event Registration MVP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'rack-cors'
 
 gem 'money-rails', '~>1.12'
 
+gem 'activerecord_json_validator'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   # gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
     activerecord (6.0.2.1)
       activemodel (= 6.0.2.1)
       activesupport (= 6.0.2.1)
+    activerecord_json_validator (1.3.0)
+      activerecord (>= 4.2.0, < 7)
+      json-schema (~> 2.8)
     activestorage (6.0.2.1)
       actionpack (= 6.0.2.1)
       activejob (= 6.0.2.1)
@@ -56,6 +59,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -74,6 +79,8 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.1)
       concurrent-ruby (~> 1.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jsonapi-resources (0.10.0)
       activerecord (>= 4.1)
       concurrent-ruby
@@ -110,6 +117,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
     rack (2.1.1)
@@ -190,6 +198,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord_json_validator
   bootsnap (>= 1.4.2)
   factory_bot_rails
   jsonapi-resources (= 0.10.0)
@@ -209,4 +218,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,4 @@ class ApplicationController < ActionController::API
   include JSONAPI::ActsAsResourceController
 
   abstract
-
-  private
-
-  def authorize_admin
-  	head :forbidden
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,10 @@ class ApplicationController < ActionController::API
   include JSONAPI::ActsAsResourceController
 
   abstract
+
+  private
+
+  def authorize_admin
+  	head :forbidden
+  end
 end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -1,3 +1,2 @@
 class EventRegistrationsController < ApplicationController
-  # before_action :authorize_admin, only: [:update, :create_relationship, :update_relationship]
 end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -1,0 +1,3 @@
+class EventRegistrationsController < ApplicationController
+  # before_action :authorize_admin, only: [:update, :create_relationship, :update_relationship]
+end

--- a/app/models/concerns/event_registration_validations.rb
+++ b/app/models/concerns/event_registration_validations.rb
@@ -1,4 +1,4 @@
-module EventRelationUtils
+module EventRegistrationValidations
   def event_is_published
     if event && !event.published?
       errors.add(:base, "Event must be published")
@@ -14,6 +14,18 @@ module EventRelationUtils
   def event_is_not_canceled
     if event && event.canceled?
       errors.add(:base, "Event is canceled")
+    end
+  end
+
+  def event_has_capacity
+    if event && event.remaining_capacity <= 0
+      errors.add(:base, "Event is at capacity")
+    end
+  end
+
+  def ticket_class_has_capacity
+    if ticket_class && ticket_class.remaining_capacity <= 0
+      errors.add(:base, "Ticket Class is at capacity")
     end
   end
 end

--- a/app/models/concerns/event_relation_utils.rb
+++ b/app/models/concerns/event_relation_utils.rb
@@ -1,0 +1,13 @@
+module EventRelationUtils
+  def event_is_published
+    if event && !event.published?
+      errors.add(:base, "Event must be published")
+    end
+  end
+
+  def event_is_upcoming
+    if event && !event.upcoming?
+      errors.add(:base, "Event must be upcoming")
+    end
+  end
+end

--- a/app/models/concerns/event_relation_utils.rb
+++ b/app/models/concerns/event_relation_utils.rb
@@ -10,4 +10,10 @@ module EventRelationUtils
       errors.add(:base, "Event must be upcoming")
     end
   end
+
+  def event_is_not_canceled
+    if event && event.canceled?
+      errors.add(:base, "Event is canceled")
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,4 +21,16 @@ class Event < ApplicationRecord
       }
     }.to_json
   end
+
+  def deleted?
+    !!deleted_at
+  end
+
+  def published?
+    !deleted? && !!published_at && published_at <= DateTime.now
+  end
+
+  def upcoming?
+    !!starting_at && starting_at > DateTime.now
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,10 @@ class Event < ApplicationRecord
   has_many :ticket_classes
   has_many :event_registrations, through: :ticket_classes
 
+  def remaining_capacity
+    capacity - event_registrations.size
+  end
+
   def registration_schema
     {
       type: 'object',

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,4 +5,20 @@ class Event < ApplicationRecord
 
   belongs_to :venue, optional: true
   has_many :ticket_classes
+  has_many :event_registrations, through: :ticket_classes
+
+  def registration_schema
+    {
+      type: 'object',
+      required: %w[firstName lastName email],
+      additionalProperties: false,
+      properties: {
+        firstName: { type: 'string' },
+        lastName: { type: 'string' },
+        email: { type: 'string' },
+        title: { type: 'string' },
+        company: { type: 'string' },
+      }
+    }.to_json
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,7 +15,10 @@ class Event < ApplicationRecord
       properties: {
         firstName: { type: 'string' },
         lastName: { type: 'string' },
-        email: { type: 'string' },
+        email: {
+          type: 'string',
+          pattern: '^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$',
+        },
         title: { type: 'string' },
         company: { type: 'string' },
       }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -36,4 +36,8 @@ class Event < ApplicationRecord
   def upcoming?
     !!starting_at && starting_at > DateTime.now
   end
+
+  def canceled?
+    !!canceled_at
+  end
 end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,0 +1,3 @@
+class EventRegistration < ApplicationRecord
+  belongs_to :ticket_class
+end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,3 +1,20 @@
 class EventRegistration < ApplicationRecord
+  validates   :data,
+              presence: true,
+              # Fetching the schema requires an event to be attached, which requires a ticket_class to be attached.
+              # So this allows those validation to run first, if they pass, then we can get the schema and validate this prop.
+              # (note) This record cannot be created without a TicketClass existing and a TicketClass can exist without an Event
+              # existing. So it's save to assume that records are not created without this validation running.
+              if: -> { event.present? },
+              json: {
+                schema: -> { registration_schema },
+                message: ->(errors) { errors }
+              }
+
   belongs_to :ticket_class
+  has_one :event, through: :ticket_class
+
+  def registration_schema
+    event.registration_schema
+  end
 end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,4 +1,9 @@
 class EventRegistration < ApplicationRecord
+  include EventRelationUtils
+
+  validate :event_is_published, :on => :create
+  validate :event_is_upcoming, :on => :create
+
   validates   :data,
               presence: true,
               # Fetching the schema requires an event to be attached, which requires a ticket_class to be attached.

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,9 +1,11 @@
 class EventRegistration < ApplicationRecord
-  include EventRelationUtils
+  include EventRegistrationValidations
 
   validate :event_is_published, :on => :create
   validate :event_is_upcoming, :on => :create
   validate :event_is_not_canceled, :on => :create
+  validate :event_has_capacity, :on => :create
+  validate :ticket_class_has_capacity, :on => :create
 
   validates   :data,
               presence: true,

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -3,6 +3,7 @@ class EventRegistration < ApplicationRecord
 
   validate :event_is_published, :on => :create
   validate :event_is_upcoming, :on => :create
+  validate :event_is_not_canceled, :on => :create
 
   validates   :data,
               presence: true,

--- a/app/models/ticket_class.rb
+++ b/app/models/ticket_class.rb
@@ -3,4 +3,12 @@ class TicketClass < ApplicationRecord
 
   belongs_to :event
   has_many :event_registrations
+
+  def remaining_capacity
+    return nil if !event
+    return event.remaining_capacity if capacity.blank?
+
+    self_remaining_capacity = capacity - event_registrations.size
+    event.remaining_capacity < self_remaining_capacity ? event.remaining_capacity : self_remaining_capacity
+  end
 end

--- a/app/models/ticket_class.rb
+++ b/app/models/ticket_class.rb
@@ -2,4 +2,5 @@ class TicketClass < ApplicationRecord
   monetize :price_cents
 
   belongs_to :event
+  has_many :event_registrations
 end

--- a/app/resources/event_registration_resource.rb
+++ b/app/resources/event_registration_resource.rb
@@ -1,0 +1,5 @@
+class EventRegistrationResource < ApplicationResource  
+  has_one :ticket_class
+  
+  attributes  :data
+end

--- a/app/resources/event_registration_resource.rb
+++ b/app/resources/event_registration_resource.rb
@@ -1,5 +1,5 @@
 class EventRegistrationResource < ApplicationResource  
   has_one :ticket_class
   
-  attributes  :data
+  attributes :data
 end

--- a/app/resources/ticket_class_resource.rb
+++ b/app/resources/ticket_class_resource.rb
@@ -6,8 +6,6 @@ class TicketClassResource < ApplicationResource
   
   attributes  :name,
               :description,
-              :minimum_quantity,
-              :maximum_quantity,
               :sorting,
               :capacity,
               :sales_start,

--- a/app/resources/ticket_class_resource.rb
+++ b/app/resources/ticket_class_resource.rb
@@ -1,7 +1,8 @@
 class TicketClassResource < ApplicationResource
   immutable
   
-  has_one :event
+  has_one   :event
+  has_many  :event_registrations
   
   attributes  :name,
               :description,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,13 @@
 Rails.application.routes.draw do
+  # TODO: add spec to verifiy routes don't get leaked
   jsonapi_resources :events do
     # Remove block to allow nested routes (i.e. /events/:id/venue)
     jsonapi_resources :ticket_classes do
 
     end
+  end
+
+  jsonapi_resources :event_registrations, only: [:create] do
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   # TODO: add spec to verifiy routes don't get leaked
-  jsonapi_resources :events do
+  jsonapi_resources :events, only: [:index, :show] do
     # Remove block to allow nested routes (i.e. /events/:id/venue)
-    jsonapi_resources :ticket_classes do
+    jsonapi_resources :ticket_classes, only: [:index, :show] do
 
     end
   end

--- a/db/migrate/20200109214559_create_events.rb
+++ b/db/migrate/20200109214559_create_events.rb
@@ -3,6 +3,7 @@ class CreateEvents < ActiveRecord::Migration[6.0]
     create_table :events do |t|
       t.string :name
       t.text :description
+      t.integer :capacity, default: 200
       t.datetime :published_at
       t.datetime :starting_at
       t.datetime :ending_at

--- a/db/migrate/20200109214559_create_events.rb
+++ b/db/migrate/20200109214559_create_events.rb
@@ -6,6 +6,7 @@ class CreateEvents < ActiveRecord::Migration[6.0]
       t.datetime :published_at
       t.datetime :starting_at
       t.datetime :ending_at
+      t.datetime :canceled_at
 
       t.references :venue, foreign_key: true
       

--- a/db/migrate/20200123050257_create_ticket_classes.rb
+++ b/db/migrate/20200123050257_create_ticket_classes.rb
@@ -12,7 +12,7 @@ class CreateTicketClasses < ActiveRecord::Migration[6.0]
       t.datetime :sales_end
       t.string :order_confirmation_message
 
-      t.references :event, foreign_key: true
+      t.references :event, null: false, foreign_key: true
 
       t.datetime :deleted_at
       t.timestamps

--- a/db/migrate/20200123050257_create_ticket_classes.rb
+++ b/db/migrate/20200123050257_create_ticket_classes.rb
@@ -3,8 +3,6 @@ class CreateTicketClasses < ActiveRecord::Migration[6.0]
     create_table :ticket_classes do |t|
       t.string :name
       t.string :description
-      t.integer :minimum_quantity
-      t.integer :maximum_quantity
       t.monetize :price
       t.integer :sorting
       t.integer :capacity

--- a/db/migrate/20200321052402_create_event_registrations.rb
+++ b/db/migrate/20200321052402_create_event_registrations.rb
@@ -1,7 +1,7 @@
 class CreateEventRegistrations < ActiveRecord::Migration[6.0]
   def change
     create_table :event_registrations do |t|
-      t.json :data
+      t.json :data, null: false
 
       t.references :ticket_class, null: false, foreign_key: true
 

--- a/db/migrate/20200321052402_create_event_registrations.rb
+++ b/db/migrate/20200321052402_create_event_registrations.rb
@@ -1,0 +1,12 @@
+class CreateEventRegistrations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :event_registrations do |t|
+      t.json :data
+
+      t.references :ticket_class, null: false, foreign_key: true
+
+      t.datetime :deleted_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2020_03_21_052402) do
 
   create_table "event_registrations", force: :cascade do |t|
-    t.json "data"
+    t.json "data", null: false
     t.integer "ticket_class_id", null: false
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2020_03_21_052402) do
     t.datetime "sales_start"
     t.datetime "sales_end"
     t.string "order_confirmation_message"
-    t.integer "event_id"
+    t.integer "event_id", null: false
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2020_03_21_052402) do
     t.datetime "published_at"
     t.datetime "starting_at"
     t.datetime "ending_at"
+    t.datetime "canceled_at"
     t.integer "venue_id"
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_23_050257) do
+ActiveRecord::Schema.define(version: 2020_03_21_052402) do
+
+  create_table "event_registrations", force: :cascade do |t|
+    t.json "data"
+    t.integer "ticket_class_id", null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ticket_class_id"], name: "index_event_registrations_on_ticket_class_id"
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "name"
@@ -58,6 +67,7 @@ ActiveRecord::Schema.define(version: 2020_01_23_050257) do
     t.index ["deleted_at"], name: "index_venues_on_deleted_at"
   end
 
+  add_foreign_key "event_registrations", "ticket_classes"
   add_foreign_key "events", "venues"
   add_foreign_key "ticket_classes", "events"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2020_03_21_052402) do
   create_table "events", force: :cascade do |t|
     t.string "name"
     t.text "description"
+    t.integer "capacity", default: 200
     t.datetime "published_at"
     t.datetime "starting_at"
     t.datetime "ending_at"
@@ -40,8 +41,6 @@ ActiveRecord::Schema.define(version: 2020_03_21_052402) do
   create_table "ticket_classes", force: :cascade do |t|
     t.string "name"
     t.string "description"
-    t.integer "minimum_quantity"
-    t.integer "maximum_quantity"
     t.integer "price_cents", default: 0, null: false
     t.string "price_currency", default: "USD", null: false
     t.integer "sorting"

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -71,8 +71,8 @@ FactoryBot.define do
       venue
 
       after(:create) do |event, evaluator|
-        create  :ticket_class, event: event, maximum_quantity: 5, sorting: 1, capacity: 10
-        create  :ticket_class, name: 'Premium', event: event, maximum_quantity: 5, sorting: 2, capacity: 10
+        create  :ticket_class, event: event, sorting: 1, capacity: 10
+        create  :ticket_class, name: 'Premium', event: event, sorting: 2, capacity: 10
       end
     end
   end

--- a/spec/factories/event_registrations.rb
+++ b/spec/factories/event_registrations.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :event_registration do
+    data { JSON({ firstName: 'Kevin', lastName: 'Mircovich', email: 'kevin@ncmamonmouth.org', title: 'Software Engineer', company: 'NCMA Monmouth' }) }
+    ticket_class { nil }
+  end
+end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe EventRegistration, :type => :model do
+  describe '#data' do
+    describe '#event' do
+      it 'references the event through the ticket_class relation' do
+        event = create(:event)
+        subject.ticket_class = create(:ticket_class, event: event)
+        
+        expect(subject.event).to eq(event)
+      end
+    end
+
+    describe '#registration_schema' do
+      it 'points to the registration_schema on the related event' do
+        event = create(:event)
+        subject.ticket_class = create(:ticket_class, event: event)
+
+        expect(subject.registration_schema).to eq(subject.event.registration_schema)
+        expect(subject.registration_schema).to eq(event.registration_schema)
+      end
+    end
+
+    describe '#save' do
+      it 'validates the presence of a ticket_class' do
+        expect(subject.save).to eq(false)
+
+        expect(subject.errors.messages[:ticket_class][0]).to eq('must exist')
+        expect(subject.errors.details[:ticket_class][0]).to eq({ :error=>:blank })
+      end
+
+      describe 'validating #data' do
+        it 'validates #data against its event\'s registration_schema when after properties are valid' do
+          data = { firstName: 'Kevin', lastName: 'Mirc', email: 'kevin@example.com' }
+
+          subject.ticket_class = create(:ticket_class, event: create(:event))
+          subject.data = data
+
+          result = subject.save
+          
+          expect(result).to eq(true)
+          expect(subject.id).to be > 0
+          expect(subject.data.to_json).to eq(data.to_json)
+        end
+
+        it 'allows other properties defined on schema' do
+          data = { firstName: 'Kevin', lastName: 'Mirc', email: 'kevin@example.com', title: 'Software Engineer', company: 'Example.com' }
+
+          subject.ticket_class = create(:ticket_class, event: create(:event))
+          subject.data = data
+
+          result = subject.save
+
+          expect(result).to eq(true)
+          expect(subject.id).to be > 0
+          expect(subject.data.to_json).to eq(data.to_json)
+        end
+
+        it 'does not accept extra properties' do
+          subject.ticket_class = create(:ticket_class, event: create(:event))
+          subject.data = { firstName: 'Kevin', lastName: 'Mirc', email: 'kevin@example.com', extra: 'property'}
+
+          result = subject.save
+
+          expect(result).to eq(false)
+
+          expect(
+            subject.errors.messages[:data][0]
+          ).to include(
+            "contains additional properties [\"extra\"] outside of the schema when none are allowed"
+          )
+        end
+
+        it 'provides errors for missing required properties properties' do
+          subject.ticket_class = create(:ticket_class, event: create(:event))
+          subject.data = {}
+
+          result = subject.save
+
+          expect(result).to eq(false)
+
+          expect(
+            subject.errors.messages[:data][0]
+          ).to include(
+            "can't be blank"
+          )
+
+          expect(
+            subject.errors.messages[:data][1]
+          ).to include(
+            "did not contain a required property of 'firstName'"
+          )
+
+          expect(
+            subject.errors.messages[:data][2]
+          ).to include(
+            "did not contain a required property of 'lastName'"
+          )
+
+          expect(
+            subject.errors.messages[:data][3]
+          ).to include(
+            "did not contain a required property of 'email'"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe EventRegistration, :type => :model do
           )
         end
 
-        it 'provides errors for missing required properties properties' do
+        it 'provides errors for missing required properties' do
           subject.ticket_class = create(:ticket_class, event: create(:event))
           subject.data = {}
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Event, :type => :model do
+  describe 'deleted?' do
+    it 'returns true if deleted_at is set' do
+      expect(subject.deleted?).to eq(false)
+
+      subject.deleted_at = DateTime.now
+      expect(subject.deleted?).to eq(true)
+    end
+  end
+
+  describe 'published?' do
+    it 'returns false if published_at is not set' do
+      expect(subject.published?).to eq(false)
+    end
+
+    it 'returns false if deleted_at is set' do
+      expect(subject.published?).to eq(false)
+
+      subject.deleted_at = DateTime.now
+      expect(subject.published?).to eq(false)
+    end
+
+    it 'returns false if published_at grater than now' do
+      expect(subject.published?).to eq(false)
+
+      subject.published_at = DateTime.now + 1.day
+      expect(subject.published?).to eq(false)
+    end
+
+    it 'returns true if published_at is less than or eq to DateTime.now' do
+      expect(subject.published?).to eq(false)
+
+      subject.published_at = DateTime.now - 1.day
+      expect(subject.published?).to eq(true)
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe Event, :type => :model do
+  describe '#remaining_capacity' do
+    it 'defaults to 200' do
+      expect(subject.remaining_capacity).to eq(200)
+    end
+
+    it 'returns the capacity less all it\'s registrations' do
+      # Save an event
+      subject.name = 'My Event'
+      subject.starting_at = DateTime.now + 30
+      subject.published_at = DateTime.now - 1
+
+      subject.save!
+
+      # Create 2 ticket classes
+      tc_1 = create(:ticket_class, name: 'Basic', price: 0, event_id: subject.id)
+      tc_2 = create(:ticket_class, name: 'Plus', price: 0, event_id: subject.id)
+
+      # Create 4 registrations (2 for each ticket class)
+      create(:event_registration, ticket_class: tc_1)
+      create(:event_registration, ticket_class: tc_1)
+      create(:event_registration, ticket_class: tc_2)
+      create(:event_registration, ticket_class: tc_2)
+
+      expect(subject.remaining_capacity).to eq(200 - 4)
+    end
+  end
+
   describe '#deleted?' do
     it 'returns true if deleted_at is set' do
       expect(subject.deleted?).to eq(false)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Event, :type => :model do
-  describe 'deleted?' do
+  describe '#deleted?' do
     it 'returns true if deleted_at is set' do
       expect(subject.deleted?).to eq(false)
 
@@ -10,7 +10,36 @@ RSpec.describe Event, :type => :model do
     end
   end
 
-  describe 'published?' do
+  describe '#canceled?' do
+    it 'returns true if canceled_at is set' do
+      expect(subject.canceled?).to eq(false)
+
+      subject.canceled_at = DateTime.now
+      expect(subject.canceled?).to eq(true)
+    end
+  end
+
+  describe '#upcoming?' do
+    it 'returns false if starting_at is not set' do
+      expect(subject.upcoming?).to eq(false)
+    end
+
+    it 'returns true if starting_at greater than now' do
+      expect(subject.upcoming?).to eq(false)
+
+      subject.starting_at = DateTime.now + 1.day
+      expect(subject.upcoming?).to eq(true)
+    end
+
+    it 'returns false if starting_at is less than now' do
+      expect(subject.upcoming?).to eq(false)
+
+      subject.starting_at = DateTime.now - 1.day
+      expect(subject.upcoming?).to eq(false)
+    end
+  end
+
+  describe '#published?' do
     it 'returns false if published_at is not set' do
       expect(subject.published?).to eq(false)
     end
@@ -22,14 +51,14 @@ RSpec.describe Event, :type => :model do
       expect(subject.published?).to eq(false)
     end
 
-    it 'returns false if published_at grater than now' do
+    it 'returns false if published_at greater than now' do
       expect(subject.published?).to eq(false)
 
       subject.published_at = DateTime.now + 1.day
       expect(subject.published?).to eq(false)
     end
 
-    it 'returns true if published_at is less than or eq to DateTime.now' do
+    it 'returns true if published_at is less than or eq to now' do
       expect(subject.published?).to eq(false)
 
       subject.published_at = DateTime.now - 1.day

--- a/spec/models/ticket_class_spec.rb
+++ b/spec/models/ticket_class_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe TicketClass, :type => :model do
+  describe '#remaining_capacity' do
+
+    context 'when capacity is nil' do
+      it 'defaults to event.remaining_capacity' do
+        expect(subject.remaining_capacity).to eq(nil) # no event is attached
+
+        event = create(:event)
+        subject.event = event
+
+        expect(subject.remaining_capacity).to eq(200)
+        expect(subject.remaining_capacity).to eq(event.remaining_capacity)
+      end
+    end
+
+    context 'when capacity is defined' do
+      it 'returns the capacity less all it\'s registrations' do
+        event = create(:published_future_event)
+
+        subject.name = 'General Entry'
+        subject.price = 0
+        subject.event_id = event.id
+        subject.capacity = 8
+
+        subject.save!
+
+        # Create 4 registrations (2 for the ticket class)
+        create(:event_registration, ticket_class_id: subject.id)
+        create(:event_registration, ticket_class_id: subject.id)
+        create(:event_registration, ticket_class_id: subject.id)
+        create(:event_registration, ticket_class_id: subject.id)
+
+        expect(subject.remaining_capacity).to eq(4)
+      end
+
+      it "will be the event's remaining capacity if the event's remaining capacity is less than the ticket class's capacity" do
+        event = create(:published_future_event, capacity: 4)
+
+        subject.name = 'General Entry'
+        subject.price = 0
+        subject.event_id = event.id
+        subject.capacity = 8
+
+        subject.save!
+
+        # Create 4 registrations (2 for the ticket class)
+        create(:event_registration, ticket_class_id: subject.id)
+        create(:event_registration, ticket_class_id: subject.id)
+
+        expect(subject.remaining_capacity).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/requests/free_event_registration_spec.rb
+++ b/spec/requests/free_event_registration_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Free Event Registration', :type => :request do
+  let (:headers) { { Accept: 'application/vnd.api+json', 'Content-Type': 'application/vnd.api+json' } }
+
+  before do
+    @event = create(:published_future_event_with_venue, name: 'AMA Webinar')
+    @ticket_class = create(:ticket_class, event_id: @event.id, price: 0, name: 'General Registration')
+  end
+
+  after do
+    # @ticket_class.destroy
+    # @event.venue.destroy
+    # @event.destroy
+  end
+
+  it 'allows anyone to register without payment' do
+    request_body = {
+      data: {
+        type: 'eventRegistrations',
+        attributes: {
+          data: JSON(build(:event_registration).data)
+        },
+        relationships: {
+          ticketClass: {
+            data: {
+              type: 'ticketClasses',
+              id: @ticket_class.id
+            }
+          }
+        }
+      }
+    }
+
+    # post "/events/#{@event.id}/ticket-classes/#{@ticket_class.id}/event-registrations", params: request_body, headers: headers, as: :json
+    post "/event-registrations", params: request_body, headers: headers, as: :json
+
+    expect(response.status).to eq(201)
+
+    res_body = JSON(response.body)
+
+    expect(res_body['data']['id']).to be_present
+    expect(res_body['data']['type']).to eq 'eventRegistrations'
+    expect(res_body['data']['attributes']).to be_present
+    expect(res_body['data']['attributes']['createdAt']).to be_present
+    expect(res_body['data']['attributes']['updatedAt']).to be_present
+    expect(res_body['data']['attributes']['data']['firstName']).to eq 'Kevin'
+    expect(res_body['data']['attributes']['data']['lastName']).to eq 'Mircovich'
+    expect(res_body['data']['attributes']['data']['email']).to eq 'kevin@ncmamonmouth.org'
+    expect(res_body['data']['attributes']['data']['title']).to eq 'Software Engineer'
+    expect(res_body['data']['attributes']['data']['company']).to eq 'NCMA Monmouth'
+  end
+end

--- a/spec/requests/free_event_registration_spec.rb
+++ b/spec/requests/free_event_registration_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe 'Free Event Registration', :type => :request do
   end
 
   after do
-    # @ticket_class.destroy
-    # @event.venue.destroy
-    # @event.destroy
+    @ticket_class.event_registrations.destroy_all
+    @ticket_class.destroy
+    deleted_event = @event.destroy
+    deleted_event.venue.destroy
   end
 
   it 'allows anyone to register without payment' do
@@ -32,7 +33,6 @@ RSpec.describe 'Free Event Registration', :type => :request do
       }
     }
 
-    # post "/events/#{@event.id}/ticket-classes/#{@ticket_class.id}/event-registrations", params: request_body, headers: headers, as: :json
     post "/event-registrations", params: request_body, headers: headers, as: :json
 
     expect(response.status).to eq(201)

--- a/spec/requests/list_events_spec.rb
+++ b/spec/requests/list_events_spec.rb
@@ -177,9 +177,6 @@ RSpec.describe 'Event List', :type => :request do
       expect(ticketClass1['attributes']['price']['value']).to eq(expected_event_3.ticket_classes[0].price.cents)
       expect(ticketClass1['attributes']['price']['display']).to eq(expected_event_3.ticket_classes[0].price.format)
       expect(ticketClass1['attributes']['price']['currency']).to eq(expected_event_3.ticket_classes[0].price.currency.iso_code)
-      expect(ticketClass1['attributes']['minimumQuantity']).to eq(expected_event_3.ticket_classes[0].minimum_quantity)
-
-      expect(ticketClass1['attributes']['maximumQuantity']).to eq(expected_event_3.ticket_classes[0].maximum_quantity)
       expect(ticketClass1['attributes']['sorting']).to eq(expected_event_3.ticket_classes[0].sorting)
       expect(ticketClass1['attributes']['capacity']).to eq(expected_event_3.ticket_classes[0].capacity)
       expect(ticketClass1['attributes']['salesStart']).to eq(expected_event_3.ticket_classes[0].sales_start)
@@ -193,8 +190,6 @@ RSpec.describe 'Event List', :type => :request do
       expect(ticketClass2['attributes']['price']['value']).to eq(expected_event_3.ticket_classes[1].price.cents)
       expect(ticketClass2['attributes']['price']['display']).to eq(expected_event_3.ticket_classes[1].price.format)
       expect(ticketClass2['attributes']['price']['currency']).to eq(expected_event_3.ticket_classes[1].price.currency.iso_code)
-      expect(ticketClass2['attributes']['minimumQuantity']).to eq(expected_event_3.ticket_classes[1].minimum_quantity)
-      expect(ticketClass2['attributes']['maximumQuantity']).to eq(expected_event_3.ticket_classes[1].maximum_quantity)
       expect(ticketClass2['attributes']['sorting']).to eq(expected_event_3.ticket_classes[1].sorting)
       expect(ticketClass2['attributes']['capacity']).to eq(expected_event_3.ticket_classes[1].capacity)
       expect(ticketClass2['attributes']['salesStart']).to eq(expected_event_3.ticket_classes[1].sales_start)

--- a/spec/requests/list_ticket_classes_spec.rb
+++ b/spec/requests/list_ticket_classes_spec.rb
@@ -49,9 +49,7 @@ RSpec.describe 'List Ticket Classes', :type => :request do
       expect(ticketClass1['attributes']['price']['value']).to eq(event.ticket_classes[0].price.cents)
       expect(ticketClass1['attributes']['price']['display']).to eq(event.ticket_classes[0].price.format)
       expect(ticketClass1['attributes']['price']['currency']).to eq(event.ticket_classes[0].price.currency.iso_code)
-      expect(ticketClass1['attributes']['minimumQuantity']).to eq(event.ticket_classes[0].minimum_quantity)
 
-      expect(ticketClass1['attributes']['maximumQuantity']).to eq(event.ticket_classes[0].maximum_quantity)
       expect(ticketClass1['attributes']['sorting']).to eq(event.ticket_classes[0].sorting)
       expect(ticketClass1['attributes']['capacity']).to eq(event.ticket_classes[0].capacity)
       expect(ticketClass1['attributes']['salesStart']).to eq(event.ticket_classes[0].sales_start)
@@ -65,8 +63,6 @@ RSpec.describe 'List Ticket Classes', :type => :request do
       expect(ticketClass2['attributes']['price']['value']).to eq(event.ticket_classes[1].price.cents)
       expect(ticketClass2['attributes']['price']['display']).to eq(event.ticket_classes[1].price.format)
       expect(ticketClass2['attributes']['price']['currency']).to eq(event.ticket_classes[1].price.currency.iso_code)
-      expect(ticketClass2['attributes']['minimumQuantity']).to eq(event.ticket_classes[1].minimum_quantity)
-      expect(ticketClass2['attributes']['maximumQuantity']).to eq(event.ticket_classes[1].maximum_quantity)
       expect(ticketClass2['attributes']['sorting']).to eq(event.ticket_classes[1].sorting)
       expect(ticketClass2['attributes']['capacity']).to eq(event.ticket_classes[1].capacity)
       expect(ticketClass2['attributes']['salesStart']).to eq(event.ticket_classes[1].sales_start)


### PR DESCRIPTION
**Description**
Allow unauthenticated users to register to events.

**MVP Requirements**
- [x] Must store the registration
- [x] Must collect the contact info of the registrant
- [x] Registration data is verified against the event.registration_schema (or for now a hardcoded schema for all events)
- [x] Add validation of the format for the email in the registration schema
`value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i`
- [x] (?) Sends email confirmation
Done in Followup Ticket: https://github.com/ncma-chapters/team/issues/35
- [x] Should decrement the event/ticket class capacity

**Considerations**
- [x] Do we want to limit one registration per email provided?
No. Let people register twice.
- [x] What If I want to register multiple tickets in one step
Quick and dirty: We can have a self-referencing table. If a EventRegistration points to another one, we know that it was part of that parent one.
This can be followup work if requested from users/stakeholders.
- [x] What if a malicious user spams this endpoint?
Strong rate-limiting settings should be set for this endpoint. We should also have a default capacity for each event of 200. To limit the amount of DB capacity a malicious user could fill.
Added ticket for this: https://github.com/ncma-chapters/team/issues/38
- [x] Cannot register to past events
- [x] Cannot register to canceled events
- [x] Cannot register to unpublished events
- [x] Cannot GET the created registration

